### PR TITLE
Fix FileNotFoundError on Windows when running webtorrent subprocess

### DIFF
--- a/src/stream.py
+++ b/src/stream.py
@@ -26,4 +26,4 @@ def stream(magnet: str, default_player: str) -> None:
     run the process.
     '''
     
-    subprocess.run(["webtorrent", magnet, f"--{default_player}"], check=True)
+    subprocess.run(["webtorrent", magnet, f"--{default_player}"], check=True, shell=True)


### PR DESCRIPTION
This fixes the `FileNotFoundError` error on Windows when calling the `stream` function in [`stream.py`](https://github.com/redelka00/stream-cli/blob/main/src/stream.py) file.

I added the `shell=True` parameter to the `subprocess.run` function.